### PR TITLE
chore: remove funding data fetch from training pipeline end to end

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -1198,7 +1198,7 @@ async def _retrain_background(application, chat_id) -> None:
 
     try:
         loop = _asyncio.get_event_loop()
-        log.info("Retrain: fetching 9 months of MEXC data...")
+        log.info("Retrain: fetching 9 months of training inputs...")
         data = await _asyncio.wait_for(
             loop.run_in_executor(None, lambda: data_fetcher.fetch_all(months=9)),
             timeout=1500,

--- a/ml/data_fetcher.py
+++ b/ml/data_fetcher.py
@@ -126,272 +126,7 @@ def fetch_1h(start_ms: int, end_ms: int) -> pd.DataFrame:
 
 
 # ---------------------------------------------------------------------------
-# Section 3.4 — Funding rate history
-# ---------------------------------------------------------------------------
-
-MEXC_FUNDING_URL = "https://contract.mexc.com/api/v1/contract/funding_rate/history"
-_FUNDING_INTERVAL_MS = 8 * 60 * 60 * 1000
-
-
-def _funding_records_to_df(records: list, start_ms: int, end_ms: int) -> pd.DataFrame:
-    """Deduplicate, filter to [start_ms, end_ms], sort, and return clean DataFrame."""
-    if not records:
-        return pd.DataFrame(columns=["timestamp", "funding_rate"])
-    df = pd.DataFrame(records)
-    df = df.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)
-    start_dt = pd.Timestamp(start_ms, unit="ms", tz="UTC")
-    end_dt = pd.Timestamp(end_ms, unit="ms", tz="UTC")
-    df = df[(df["timestamp"] >= start_dt) & (df["timestamp"] < end_dt)].reset_index(drop=True)
-    return df
-
-
-def _estimate_funding_points(start_ms: int, end_ms: int) -> int:
-    if end_ms <= start_ms:
-        return 0
-    return max(int(np.ceil((end_ms - start_ms) / _FUNDING_INTERVAL_MS)), 1)
-
-
-def _funding_coverage_summary(df: pd.DataFrame, start_ms: int, end_ms: int) -> dict:
-    expected = _estimate_funding_points(start_ms, end_ms)
-    if df is None or df.empty:
-        return {
-            "records": 0,
-            "expected_records": expected,
-            "record_coverage": 0.0,
-            "time_coverage": 0.0,
-            "start": None,
-            "end": None,
-        }
-    actual = int(len(df))
-    time_span_ms = max(end_ms - start_ms, 1)
-    covered_ms = max(int((df["timestamp"].max() - df["timestamp"].min()).total_seconds() * 1000), 0)
-    return {
-        "records": actual,
-        "expected_records": expected,
-        "record_coverage": min(actual / max(expected, 1), 1.0),
-        "time_coverage": min(covered_ms / time_span_ms, 1.0),
-        "start": df["timestamp"].iloc[0],
-        "end": df["timestamp"].iloc[-1],
-    }
-
-
-def _fetch_funding_ccxt(exchange, start_ms: int, end_ms: int) -> list:
-    """Paginate ccxt funding history forward across long windows.
-
-    Some MEXC/ccxt responses arrive newest-first and some repeat the same page
-    boundary across successive calls. Advancing via batch[-1] can therefore stall
-    after roughly one page (~100 records). Instead we:
-      - parse all timestamps in the batch,
-      - keep only records at or after the current since cursor,
-      - advance using the newest unseen timestamp from that filtered slice.
-    This preserves the direct ccxt funding path and only falls back when the
-    exchange truly stops yielding forward progress.
-    """
-    records = []
-    since = start_ms
-    prev_advance_ts: int | None = None
-
-    while since < end_ms:
-        try:
-            batch = exchange.fetch_funding_rate_history("BTC/USDT:USDT", since=since, limit=100)
-        except Exception as e:
-            log.warning("ccxt fetch_funding_rate_history error since=%d: %s", since, e)
-            break
-        if not batch:
-            break
-
-        parsed_rows = []
-        for r in batch:
-            ts = r.get("timestamp")
-            rate = r.get("fundingRate")
-            if ts is None or rate is None:
-                continue
-            ts_int = int(ts)
-            parsed_rows.append((ts_int, float(rate)))
-            records.append({
-                "timestamp": pd.Timestamp(ts_int, unit="ms", tz="UTC"),
-                "funding_rate": float(rate),
-            })
-
-        if not parsed_rows:
-            log.warning("ccxt funding batch had no parseable records since=%d", since)
-            break
-
-        forward_rows = [ts for ts, _ in parsed_rows if since <= ts < end_ms]
-        if not forward_rows:
-            batch_min_ts = min(ts for ts, _ in parsed_rows)
-            batch_max_ts = max(ts for ts, _ in parsed_rows)
-            log.warning(
-                "ccxt funding pagination produced no forward progress since=%d batch_min=%d batch_max=%d; falling back to REST pagination",
-                since,
-                batch_min_ts,
-                batch_max_ts,
-            )
-            break
-
-        advance_ts = max(forward_rows)
-        if advance_ts == prev_advance_ts:
-            log.warning("ccxt funding pagination stalled at ts=%d; falling back to REST pagination", advance_ts)
-            break
-        if advance_ts >= end_ms:
-            break
-
-        prev_advance_ts = advance_ts
-        since = advance_ts + 1
-        time.sleep(0.1)
-
-    return records
-
-
-def _fetch_funding_rest(start_ms: int, end_ms: int) -> list:
-    """Fetch funding history via the supported MEXC contract funding history endpoint."""
-    records = []
-    page_num = 1
-    start_dt = pd.Timestamp(start_ms, unit="ms", tz="UTC")
-    expected_points = _estimate_funding_points(start_ms, end_ms)
-
-    with httpx.Client(timeout=30) as client:
-        while True:
-            params = {
-                "symbol": "BTC_USDT",
-                "page_num": page_num,
-                "page_size": 100,
-            }
-            try:
-                resp = client.get(MEXC_FUNDING_URL, params=params)
-                resp.raise_for_status()
-                data = resp.json()
-            except Exception as e:
-                log.warning("MEXC REST funding page %d error: %s", page_num, e)
-                break
-
-            page_data = data.get("data", {})
-            total_pages = None
-            total_count = None
-            if isinstance(page_data, dict):
-                items = page_data.get("resultList", page_data.get("result", []))
-                total_pages = page_data.get("totalPage")
-                total_count = page_data.get("totalCount")
-            elif isinstance(page_data, list):
-                items = page_data
-            else:
-                items = []
-
-            if not items:
-                log.info("MEXC REST funding page %d returned empty; stopping pagination", page_num)
-                break
-
-            page_records = []
-            for item in items:
-                ts = item.get("settleTime")
-                rate = item.get("fundingRate")
-                if ts is None or rate is None:
-                    continue
-                page_records.append({
-                    "timestamp": pd.Timestamp(int(ts), unit="ms", tz="UTC"),
-                    "funding_rate": float(rate),
-                })
-
-            if not page_records:
-                log.warning("MEXC REST funding page %d had no parseable records; stopping pagination", page_num)
-                break
-
-            records.extend(page_records)
-            oldest_ts = min(r["timestamp"] for r in page_records)
-            newest_ts = max(r["timestamp"] for r in page_records)
-            log.info(
-                "MEXC REST funding page %d: parsed=%d oldest=%s newest=%s total_count=%s total_pages=%s",
-                page_num,
-                len(page_records),
-                oldest_ts.isoformat(),
-                newest_ts.isoformat(),
-                total_count,
-                total_pages,
-            )
-
-            reached_start = oldest_ts <= start_dt
-            reached_expected = len(records) >= expected_points
-            reached_last_page = isinstance(total_pages, int) and page_num >= total_pages
-            if reached_start or reached_expected or reached_last_page:
-                if reached_start:
-                    log.info("MEXC REST funding reached requested start boundary at page %d", page_num)
-                elif reached_expected:
-                    log.info("MEXC REST funding reached expected record count (%d) at page %d", expected_points, page_num)
-                else:
-                    log.info("MEXC REST funding reached final page %d of %s", page_num, total_pages)
-                break
-
-            page_num += 1
-            time.sleep(0.1)
-
-    log.info("MEXC REST funding strategy fetched %d raw records across %d page(s)", len(records), page_num)
-    return records
-
-
-def fetch_funding(start_ms: int, end_ms: int) -> pd.DataFrame:
-    """Fetch BTC/USDT:USDT funding history with robust full-window coverage logging."""
-    coverage_threshold = 0.95
-    ccxt_df = pd.DataFrame(columns=["timestamp", "funding_rate"])
-
-    try:
-        exchange = ccxt.mexc({"options": {"defaultType": "swap"}})
-        exchange.load_markets()
-        ccxt_records = _fetch_funding_ccxt(exchange, start_ms, end_ms)
-        ccxt_df = _funding_records_to_df(ccxt_records, start_ms, end_ms)
-    except Exception as exc:
-        log.warning("fetch_funding: ccxt funding path unavailable; using REST history fallback: %s", exc)
-
-    ccxt_cov = _funding_coverage_summary(ccxt_df, start_ms, end_ms)
-    log.info(
-        "fetch_funding ccxt summary: records=%d expected=%d record_coverage=%.1f%% time_coverage=%.1f%% start=%s end=%s",
-        ccxt_cov["records"],
-        ccxt_cov["expected_records"],
-        ccxt_cov["record_coverage"] * 100,
-        ccxt_cov["time_coverage"] * 100,
-        ccxt_cov["start"].isoformat() if ccxt_cov["start"] is not None else "N/A",
-        ccxt_cov["end"].isoformat() if ccxt_cov["end"] is not None else "N/A",
-    )
-
-    if ccxt_cov["record_coverage"] >= coverage_threshold:
-        log.info("fetch_funding: ccxt provided sufficient funding history for requested window")
-        return ccxt_df
-
-    log.warning(
-        "fetch_funding: insufficient ccxt funding coverage for requested window; switching to REST history (record_coverage=%.1f%% threshold=%.0f%%)",
-        ccxt_cov["record_coverage"] * 100,
-        coverage_threshold * 100,
-    )
-    rest_records = _fetch_funding_rest(start_ms, end_ms)
-    rest_df = _funding_records_to_df(rest_records, start_ms, end_ms)
-    rest_cov = _funding_coverage_summary(rest_df, start_ms, end_ms)
-    log.info(
-        "fetch_funding REST summary: records=%d expected=%d record_coverage=%.1f%% time_coverage=%.1f%% start=%s end=%s",
-        rest_cov["records"],
-        rest_cov["expected_records"],
-        rest_cov["record_coverage"] * 100,
-        rest_cov["time_coverage"] * 100,
-        rest_cov["start"].isoformat() if rest_cov["start"] is not None else "N/A",
-        rest_cov["end"].isoformat() if rest_cov["end"] is not None else "N/A",
-    )
-    if rest_cov["record_coverage"] > 0:
-        if rest_cov["record_coverage"] < coverage_threshold:
-            log.warning(
-                "fetch_funding: REST history still sparse for requested window (record_coverage=%.1f%% expected=%d actual=%d)",
-                rest_cov["record_coverage"] * 100,
-                rest_cov["expected_records"],
-                rest_cov["records"],
-            )
-        return rest_df
-
-    log.warning(
-        "fetch_funding: REST history returned no usable records; falling back to ccxt partial data (%d records)",
-        ccxt_cov["records"],
-    )
-    return ccxt_df if not ccxt_df.empty else pd.DataFrame(columns=["timestamp", "funding_rate"])
-
-
-# ---------------------------------------------------------------------------
-# Section 3.5 — CVD via MEXC futures REST (real aggressor-side data)
+# Section 3.4 — CVD via MEXC futures REST (real aggressor-side data)
 # ---------------------------------------------------------------------------
 
 def _kline_vol_to_buy_sell(open_: float, high: float, low: float, close: float, vol: float):
@@ -782,13 +517,13 @@ def fetch_live_gate_cvd(limit: int = 400) -> pd.DataFrame:
 
 
 # ---------------------------------------------------------------------------
-# fetch_all — fetch last N months of all 5 sources
+# Training fetch bundle — fetch last N months of active training inputs
 # ---------------------------------------------------------------------------
 
 def fetch_all(months: int = 5) -> dict:
-    """Fetch all 5 data sources for the last `months` months.
+    """Fetch the active training inputs for the last `months` months.
 
-    Returns dict with keys: df5, df15, df1h, funding, cvd
+    Returns dict with keys: df5, df15, df1h, cvd
       cvd — Gate.io 5m taker buy/sell volume (long_taker_size, short_taker_size, open_interest)
     """
     now = datetime.now(timezone.utc)
@@ -810,15 +545,12 @@ def fetch_all(months: int = 5) -> dict:
     df1h = fetch_1h(start_ms, end_ms)
     print(f"  -> {len(df1h)} 1h candles")
 
-    print("  Fetching funding rate history...")
-    funding = fetch_funding(start_ms, end_ms)
-    print(f"  -> {len(funding)} funding records")
 
     print("  Fetching Gate.io CVD (taker buy/sell volume)...")
     cvd = fetch_gate_cvd(start_ms, end_ms)
     print(f"  -> {len(cvd)} CVD candles")
 
-    return {"df5": df5, "df15": df15, "df1h": df1h, "funding": funding, "cvd": cvd}
+    return {"df5": df5, "df15": df15, "df1h": df1h, "cvd": cvd}
 
 
 # ---------------------------------------------------------------------------
@@ -848,41 +580,6 @@ def fetch_live_1h(limit: int = 60) -> pd.DataFrame:
     df = _ohlcv_to_df(ohlcv)
     return df.sort_values("timestamp").reset_index(drop=True)
 
-
-def fetch_live_funding() -> float | None:
-    """Fetch the current funding rate for BTC/USDT:USDT. Returns single float."""
-    try:
-        exchange = ccxt.mexc({"options": {"defaultType": "swap"}})
-        result = exchange.fetch_funding_rate("BTC/USDT:USDT")
-        return float(result.get("fundingRate", 0.0))
-    except Exception as e:
-        log.warning("fetch_live_funding error: %s", e)
-        return None
-
-
-def fetch_live_funding_history(n_periods: int = 24) -> list[float]:
-    """Fetch the last `n_periods` historical funding rates for seeding the zscore buffer.
-
-    MEXC funding is every 8 hours (3/day). 24 periods = 8 days of history.
-    Returns a list of floats sorted oldest-first, ready to populate a deque(maxlen=24).
-    """
-    # 24 periods * 8h = 192h back; add margin to ensure we get enough records
-    now = datetime.now(timezone.utc)
-    start = now - timedelta(hours=(n_periods + 4) * 8)
-    start_ms = int(start.timestamp() * 1000)
-    end_ms = int(now.timestamp() * 1000)
-
-    try:
-        df = fetch_funding(start_ms, end_ms)
-        if df.empty:
-            return []
-        # Return the last n_periods values, oldest-first
-        rates = df["funding_rate"].tail(n_periods).tolist()
-        log.info("fetch_live_funding_history: fetched %d records for buffer seed", len(rates))
-        return rates
-    except Exception as e:
-        log.warning("fetch_live_funding_history error: %s", e)
-        return []
 
 
 def _fetch_live_cvd_from_deals(n_candles: int = 400) -> pd.DataFrame:

--- a/run_training.py
+++ b/run_training.py
@@ -5,7 +5,7 @@ sys.path.insert(0, site.getusersitepackages())
 sys.path.insert(0, '/home/nebula/nyxml4')
 from ml import data_fetcher, features as feat_eng, trainer, model_store
 
-print('Fetching 9 months of MEXC data...')
+print('Fetching 9 months of training data...')
 data = data_fetcher.fetch_all(months=9)
 print(f'5m: {len(data["df5"])}, 15m: {len(data["df15"])}, 1h: {len(data["df1h"])}, cvd: {len(data["cvd"])}')
 

--- a/tests/test_ml_features.py
+++ b/tests/test_ml_features.py
@@ -172,7 +172,7 @@ def test_live_features_match_training_for_latest_closed_5m_row():
       - 15m/1h context is selected by timestamp <= ts_n1, not by blindly
         dropping the latest higher-timeframe row.
 
-    This test builds synthetic aligned 5m/15m/1h/funding data, then checks
+    This test builds synthetic aligned 5m/15m/1h data, then checks
     that build_live_features(...) equals the corresponding row from
     build_features(...), feature-by-feature.
     """
@@ -234,161 +234,28 @@ def test_live_features_match_training_for_latest_closed_5m_row():
 
 
 
-def test_fetch_funding_mock():
-    """Verify fetch_funding() behaviour using mocked ccxt and MEXC REST API.
+def test_fetch_all_returns_active_training_inputs_only():
+    """fetch_all should return only the active no-funding training inputs."""
+    from unittest.mock import patch
+    from ml.data_fetcher import fetch_all
 
-    Scenarios tested:
-      (a) ccxt pagination stalls with no forward progress -> stops ccxt loop
-      (b) ccxt coverage is sparse -> falls back to MEXC REST API
-      (c) REST results are deduplicated (duplicate settleTime entries collapsed)
-      (d) Records outside [start_ms, end_ms) are filtered out
-    """
-    import sys
-    sys.path.insert(0, '/home/nebula/nyxml4')
+    fake_df5 = pd.DataFrame({"timestamp": pd.to_datetime(["2026-01-01T00:00:00Z"]), "open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0], "volume": [1.0]})
+    fake_df15 = fake_df5.copy()
+    fake_df1h = fake_df5.copy()
+    fake_cvd = pd.DataFrame({"timestamp": pd.to_datetime(["2026-01-01T00:00:00Z"]), "long_taker_size": [1.0], "short_taker_size": [1.0], "open_interest": [1.0]})
 
-    from unittest.mock import patch, MagicMock
-    import ml.data_fetcher as df_module
-    from ml.data_fetcher import fetch_funding
+    with patch("ml.data_fetcher.fetch_5m", return_value=fake_df5), \
+         patch("ml.data_fetcher.fetch_15m", return_value=fake_df15), \
+         patch("ml.data_fetcher.fetch_1h", return_value=fake_df1h), \
+         patch("ml.data_fetcher.fetch_gate_cvd", return_value=fake_cvd):
+        result = fetch_all(months=1)
 
-    now_ms = 1_700_000_000_000
-    start_ms = now_ms - 10 * 24 * 3600 * 1000
-    end_ms   = now_ms
-
-    ccxt_ts_1 = end_ms - 3 * 8 * 3600 * 1000
-    ccxt_ts_2 = end_ms - 2 * 8 * 3600 * 1000
-    ccxt_ts_3 = end_ms - 1 * 8 * 3600 * 1000
-    ccxt_page1 = [
-        {"timestamp": ccxt_ts_3, "fundingRate": 0.0003},
-        {"timestamp": ccxt_ts_2, "fundingRate": 0.0002},
-        {"timestamp": ccxt_ts_1, "fundingRate": 0.0001},
-    ]
-    ccxt_page2 = [
-        {"timestamp": ccxt_ts_3, "fundingRate": 0.0003},
-    ]
-
-    mock_exchange = MagicMock()
-    mock_exchange.fetch_funding_rate_history.side_effect = [ccxt_page1, ccxt_page2]
-
-    interval_ms = 8 * 3600 * 1000
-
-    def make_rest_items(ts_list):
-        return [{"settleTime": str(ts), "fundingRate": str(round(0.0001 * (i + 1), 6))}
-                for i, ts in enumerate(ts_list)]
-
-    rest_page1_ts = [end_ms - i * interval_ms for i in range(1, 6)]
-    rest_page1_items = make_rest_items(rest_page1_ts)
-
-    rest_page2_ts = [end_ms - i * interval_ms for i in range(5, 11)]
-    rest_page2_ts.append(start_ms - interval_ms)
-    rest_page2_ts.append(rest_page1_ts[-1])
-    rest_page2_items = make_rest_items(rest_page2_ts)
-
-    rest_page3_items: list = []
-
-    def mock_httpx_get(url, params=None, **kwargs):
-        page = int((params or {}).get("page_num", 1))
-        if page == 1:
-            items = rest_page1_items
-        elif page == 2:
-            items = rest_page2_items
-        else:
-            items = rest_page3_items
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"data": {"resultList": items}}
-        mock_resp.raise_for_status.return_value = None
-        return mock_resp
-
-    with patch.object(df_module.ccxt, "mexc", return_value=mock_exchange), \
-         patch("ml.data_fetcher.httpx.Client") as mock_client_cls, \
-         patch("ml.data_fetcher.time.sleep"):
-
-        mock_client_instance = MagicMock()
-        mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
-        mock_client_instance.__exit__ = MagicMock(return_value=False)
-        mock_client_instance.get.side_effect = mock_httpx_get
-        mock_client_cls.return_value = mock_client_instance
-
-        result = fetch_funding(start_ms, end_ms)
-
-    assert mock_exchange.fetch_funding_rate_history.call_count == 2, (
-        f"Expected 2 ccxt calls (page1 + no-progress page2), got {mock_exchange.fetch_funding_rate_history.call_count}"
-    )
-    assert mock_client_instance.get.call_count >= 2, (
-        f"Expected REST fallback with >= 2 GET calls, got {mock_client_instance.get.call_count}"
-    )
-    assert isinstance(result, pd.DataFrame), "fetch_funding must return a DataFrame"
-    assert list(result.columns) == ["timestamp", "funding_rate"], (
-        f"Unexpected columns: {list(result.columns)}"
-    )
-    assert result["timestamp"].duplicated().sum() == 0, "Result contains duplicate timestamps"
-
-    start_dt = pd.Timestamp(start_ms, unit="ms", tz="UTC")
-    end_dt   = pd.Timestamp(end_ms,   unit="ms", tz="UTC")
-    assert (result["timestamp"] >= start_dt).all(), "Some records are before start_ms"
-    assert (result["timestamp"] < end_dt).all(),    "Some records are at or after end_ms"
-    assert result["timestamp"].is_monotonic_increasing, "Result is not sorted ascending"
-    assert result["funding_rate"].dtype == float, (
-        f"funding_rate dtype should be float, got {result['funding_rate'].dtype}"
-    )
-
-
-def test_fetch_funding_ccxt_descending_pages_accumulates_beyond_single_page():
-    """Descending ccxt pages should still advance across a long window.
-
-    This is the regression guard for the one-page failure mode: when MEXC/ccxt
-    returns newest-first pages, advancing via batch[-1] stalls near the first
-    page boundary. The funding path should instead keep moving forward and collect
-    materially more than 100 records without invoking REST fallback.
-    """
-    import sys
-    sys.path.insert(0, '/home/nebula/nyxml4')
-
-    from unittest.mock import patch, MagicMock
-    import ml.data_fetcher as df_module
-    from ml.data_fetcher import fetch_funding
-
-    interval_ms = 8 * 3600 * 1000
-    expected_points = 120
-    start_ms = 1_700_000_000_000
-    end_ms = start_ms + expected_points * interval_ms
-    all_ts = [start_ms + i * interval_ms for i in range(expected_points)]
-
-    def make_desc_page(start_idx, size):
-        ts_slice = all_ts[start_idx:start_idx + size]
-        return [
-            {"timestamp": ts, "fundingRate": 0.0001 + idx * 1e-7}
-            for idx, ts in enumerate(reversed(ts_slice))
-        ]
-
-    ccxt_pages = [
-        make_desc_page(0, 100),
-        make_desc_page(100, 20),
-        [],
-    ]
-
-    mock_exchange = MagicMock()
-    mock_exchange.fetch_funding_rate_history.side_effect = ccxt_pages
-    mock_exchange.load_markets.return_value = None
-
-    with patch.object(df_module.ccxt, "mexc", return_value=mock_exchange), \
-         patch("ml.data_fetcher.httpx.Client") as mock_client_cls, \
-         patch("ml.data_fetcher.time.sleep"):
-
-        mock_client_instance = MagicMock()
-        mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
-        mock_client_instance.__exit__ = MagicMock(return_value=False)
-        mock_client_cls.return_value = mock_client_instance
-
-        result = fetch_funding(start_ms, end_ms)
-
-    assert mock_exchange.fetch_funding_rate_history.call_count >= 2, (
-        f"Expected multi-page ccxt pagination, got {mock_exchange.fetch_funding_rate_history.call_count} call(s)"
-    )
-    assert mock_client_instance.get.call_count == 0, "REST fallback should not be needed when ccxt pages advance"
-    assert len(result) == expected_points, f"Expected {expected_points} funding rows, got {len(result)}"
-    assert len(result) > 100, "Regression guard failed: funding retrieval did not exceed one page"
-    assert result["timestamp"].is_monotonic_increasing, "ccxt result should be sorted ascending after normalization"
-    assert result["timestamp"].duplicated().sum() == 0, "ccxt result should be deduplicated"
+    assert set(result.keys()) == {"df5", "df15", "df1h", "cvd"}
+    assert "funding" not in result
+    assert result["df5"] is fake_df5
+    assert result["df15"] is fake_df15
+    assert result["df1h"] is fake_df1h
+    assert result["cvd"] is fake_cvd
 
 
 def test_volume_ratio_n1_excludes_self_from_mean():


### PR DESCRIPTION
## Summary
This PR completes the end-to-end removal of funding data dependencies from the active ML pipeline. The previous PR removed `funding_rate` and `funding_zscore` as model features — this PR removes the last remaining funding-related code: the funding history fetch that was still being called during every retrain cycle.

## Problem
After the feature-schema cleanup (42 → 40 features), the Railway deployment logs showed retraining still fetching funding history:
```
Fetching funding rate history...
```
This was dead side-effect plumbing — the data was fetched but never used by the model.

## Changes
| File | Change |
|------|--------|
| `ml/data_fetcher.py` | Removed funding fetch from shared bulk training fetcher. Contract now returns `df5`, `df15`, `df1h`, `cvd` only. |
| `run_training.py` | Updated to match new no-funding fetch contract. Stale funding references cleaned. |
| `bot/handlers.py` | Retrain flow now uses no-funding fetch path only. |
| `tests/test_ml_features.py` | Updated to assert funding is not returned by the active training fetcher. |

## Validation
- Python bytecode compilation passes for all edited files
- Active-path grep confirms zero `funding` references in `ml/data_fetcher.py`, `run_training.py`, `bot/handlers.py`
- Module import checks pass
- Test assertions confirm no-funding fetch contract

## Result
The active app pipeline is now fully no-funding end to end:
- Feature schema: 40 features, no funding
- Offline feature build: no funding
- Live inference: no funding
- Training fetch: no funding
- Retrain handler: no funding

Next deploy log should show no `Fetching funding rate history...` line.